### PR TITLE
Python バージョンの制約を修正

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -10,7 +10,7 @@ packages = [
 ]
 
 [tool.poetry.dependencies]
-python = "==3.11.1"
+python = "^3.11.1"
 fastapi = "^0.100.0"
 uvicorn = "^0.23.0"
 python-dotenv = "^1.0.0"


### PR DESCRIPTION
- 現在の PYTHON 3.11 イメージだと 3.11.4 が入る
- 修正前の制約だと起動できない